### PR TITLE
Unable to run the command "yarn run build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Now change into the `uniswap_interface` directory.
 ```
 cd ~/uniswap-interface/how_to_deploy_uniswap/uniswap_interface
 ```
-Now run the `modify_addresses.py` script 
+Now run the `modify_addresses.py` script // this command didn't add the addresses created by deploying uniswap_v1 and uniswap_v2, it only uses the addresses of the real uniswap, why ???
 ```
 python3 modify_addresses.py
 ```

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Now change into the `uniswap_interface` directory.
 ```
 cd ~/uniswap-interface/how_to_deploy_uniswap/uniswap_interface
 ```
-Now run the `modify_addresses.py` script // this command didn't add the addresses created by deploying uniswap_v1 and uniswap_v2, it only uses the addresses of the real uniswap, why ???
+Now run the `modify_addresses.py` script // `this command didn't add the addresses created by deploying uniswap_v1 and uniswap_v2, it only uses the addresses of the real uniswap, why ???`
 ```
 python3 modify_addresses.py
 ```


### PR DESCRIPTION
I followed the steps one by one, until arriving at the command "yarn run build", that shows me:

```
root@TIKTIK:~/uniswap-interface# yarn run build
yarn run v1.22.10
$ yarn compile-contract-types && yarn i18n:extract && yarn i18n:compile && react-scripts build
$ yarn compile-external-abi-types && yarn compile-v3-contract-types
$ typechain --target ethers-v5 --out-dir src/abis/types './src/abis/**/*.json'
Successfully generated 24 typings!
$ typechain --target ethers-v5 --out-dir src/types/v3 './node_modules/@uniswap/?(v3-core|v3-periphery)/artifacts/contracts/**/*.json'
Successfully generated 80 typings!
$ lingui extract --locale en-US
$ lingui compile
Compiling message catalogs…
Done!
Creating an optimized production build...
```


and it crashes there, did you perform these steps, and it works ???
NB : I'm working on a cloud server holding an UBUNTU 20.10